### PR TITLE
Ship iwd in the base image for easy wifi access

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,8 +39,8 @@ cp -vr "$FILES" "$ROOT"
 
 mount --bind "$ROOT" "$ROOT"
 
-echo "## Installing keyring package..."
-pacstrap "$ROOT" asahilinux-keyring
+echo "## Installing base packages..."
+pacstrap "$ROOT" asahilinux-keyring iwd
 
 run_scripts() {
     group="$1"


### PR DESCRIPTION
Unless I’ve missed something, the current base image doesn’t ship with anything able to deal with wifi.
Shipping with ~wpa_supplicant~ would tremendously help people who install Asahi Linux on their laptop and don’t have an ethernet cable and dongle handy.

EDIT: changed to `iwd` instead of `wpa_supplicant` after discussion.