### PR TITLE
Add /etc/os-release and /etc/lsb-release

### DIFF
--- a/scripts/base/60-os-release.sh
+++ b/scripts/base/60-os-release.sh
@@ -3,6 +3,7 @@ set -e
 
 cat >/etc/os-release <<EOF
 NAME="Asahi Linux"
+PRETTY_NAME="Asahi Linux"
 ID=asahi
 ID_LIKE=arch
 BUILD_ID=rolling

--- a/scripts/base/60-os-release.sh
+++ b/scripts/base/60-os-release.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+cat >/etc/os-release <<EOF
+NAME="Asahi Linux"
+ID=asahi
+ID_LIKE=arch
+BUILD_ID=rolling
+HOME_URL="https://asahilinux.org/"
+DOCUMENTATION_URL="https://github.com/asahilinux/docs/wiki"
+BUG_REPORT_URL="https://github.com/AsahiLinux"
+EOF

--- a/scripts/base/60-os-release.sh
+++ b/scripts/base/60-os-release.sh
@@ -11,3 +11,9 @@ HOME_URL="https://asahilinux.org"
 DOCUMENTATION_URL="https://github.com/asahilinux/docs/wiki"
 BUG_REPORT_URL="https://github.com/AsahiLinux"
 EOF
+
+cat >/etc/lsb-release <<EOF
+DISTRIB_ID="Asahi Linux"
+DISTRIB_RELEASE="rolling"
+DISTRIB_DESCRIPTION="Asahi Linux"
+EOF

--- a/scripts/base/60-os-release.sh
+++ b/scripts/base/60-os-release.sh
@@ -6,7 +6,7 @@ NAME="Asahi Linux"
 ID=asahi
 ID_LIKE=arch
 BUILD_ID=rolling
-HOME_URL="https://asahilinux.org/"
+HOME_URL="https://asahilinux.org"
 DOCUMENTATION_URL="https://github.com/asahilinux/docs/wiki"
 BUG_REPORT_URL="https://github.com/AsahiLinux"
 EOF


### PR DESCRIPTION
Adds `/etc/os-release` as per [here](https://www.freedesktop.org/software/systemd/man/os-release.html), as well as `/etc/lsb-release` so it is now properly recognized by neofetch