### PR TITLE
Add a packages list to images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,6 +70,8 @@ make_uefi_image() {
     img="$IMAGES/$imgname"
     mkdir -p "$img"
     echo "## Making image $imgname"
+    echo "### Adding Packages List..."
+    cp "$ROOT/.manifest" "$img/packages.list"
     echo "### Creating EFI system partition tree..."
     mkdir -p "$img/esp"
     cp -r "$ROOT"/boot/efi/m1n1 "$img/esp/"

--- a/scripts/base/60-manifest.sh
+++ b/scripts/base/60-manifest.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+pacman -Q > .manifest

--- a/scripts/plasma/80-manifest.sh
+++ b/scripts/plasma/80-manifest.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+pacman -Q > .manifest


### PR DESCRIPTION
When creating an image some users might want to know which packages the image will ship. By adding a `.manifest` file to root folder. This way you may also know with which packages you had started your install of Asahi Linux.