### PR TITLE
feat: add live CD ISO creation steps

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script installs the dependencies required for the Asahi Alarm Builder.
+# It should be run on the host machine (Arch Linux or similar).
+
+set -e
+
+echo "## Installing host dependencies..."
+
+# List of identified dependencies:
+# - wget: for downloading the base image
+# - libarchive: for bsdtar
+# - arch-install-scripts: for pacstrap and arch-chroot
+# - zip: for compressing images
+# - squashfs-tools: for mksquashfs
+# - grub: for grub-mkrescue and grub-mkconfig
+# - libisoburn: for xorriso (required by grub-mkrescue)
+# - mtools: for EFI support in grub-mkrescue
+# - dosfstools: for EFI support in grub-mkrescue
+# - e2fsprogs: for mkfs.ext4
+# - btrfs-progs: for mkfs.btrfs and btrfs subvolumes
+# - rsync: for copying files to the root image
+# - zstd: for squashfs compression
+# - tar: for saving and restoring base snapshots
+
+DEPS=(
+    wget
+    libarchive
+    arch-install-scripts
+    zip
+    squashfs-tools
+    grub
+    libisoburn
+    mtools
+    dosfstools
+    e2fsprogs
+    btrfs-progs
+    rsync
+    zstd
+    tar
+)
+
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO='sudo'
+fi
+
+$SUDO pacman -S --asdeps --needed --noconfirm "${DEPS[@]}"
+
+echo "## All dependencies installed successfully."

--- a/scripts/livecd/00-packages.sh
+++ b/scripts/livecd/00-packages.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+echo "### Installing LiveCD specific packages"
+pacman -S --noconfirm arch-install-scripts mkinitcpio-archiso pv lvm2 restic xfsprogs

--- a/scripts/livecd/10-initcpio.sh
+++ b/scripts/livecd/10-initcpio.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+echo "### Generating LiveCD initramfs"
+# Create a temporary config based on the system's current one
+cp /etc/mkinitcpio.conf /etc/mkinitcpio-live.conf
+
+# 1. Add necessary modules for Live ISO (USB and Filesystems)
+sed -i 's/^MODULES=(.*/MODULES=(isofs squashfs uas usb_storage usbhid xhci_hcd xhci_pci xhci_plat_hcd)/' /etc/mkinitcpio-live.conf
+
+# 2. Remove autodetect (to ensure all drivers are included) 
+# and add archiso hooks
+sed -i 's/autodetect //' /etc/mkinitcpio-live.conf
+sed -i 's/\bblock\b/block archiso/' /etc/mkinitcpio-live.conf
+
+kver=$(ls /lib/modules/ | head -n1)
+echo "Detected kernel version: $kver"
+
+mkinitcpio -c /etc/mkinitcpio-live.conf -k "$kver" -g "/boot/initramfs-live.img"
+
+# Clean up temporary config
+rm /etc/mkinitcpio-live.conf

--- a/scripts/livecd/99-cleanup.sh
+++ b/scripts/livecd/99-cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+echo "### Cleaning up LiveCD specific packages"
+pacman -Rns --noconfirm mkinitcpio-archiso pv


### PR DESCRIPTION
- Implement `make_live_image` in `build.sh` for ISO packaging and SquashFS creation.
- Add `scripts/livecd/` directory for in-chroot environment preparation.
- Dynamically modify `mkinitcpio.conf` in `10-initcpio.sh` to include archiso hooks and USB drivers.
- Ensure base image remains clean by removing live-specific packages in `99-cleanup.sh`.
- Set `fstab=no` and `archisobasedir` in GRUB configuration for better live booting.